### PR TITLE
[feat] 카카오 로그인 응답 수정 / 거래 내역 조회 API 오류 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ src/main/resources/application.yml
 
 .DS_Store
 src/main/resources/application-prod.yml
+src/main/resources/application-prod.yml

--- a/src/main/java/com/example/onlyone/domain/user/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/onlyone/domain/user/dto/response/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.example.onlyone.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse { ;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/onlyone/domain/wallet/controller/WalletController.java
+++ b/src/main/java/com/example/onlyone/domain/wallet/controller/WalletController.java
@@ -27,7 +27,6 @@ public class WalletController {
     public ResponseEntity<?> getWalletTransactionList(@RequestParam(required = false) Filter filter,
                                                       @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
                                                       Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.OK).body(walletService.getWalletTransactionList(filter, pageable));
+        return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.success(walletService.getWalletTransactionList(filter, pageable)));
     }
-
 }

--- a/src/main/java/com/example/onlyone/domain/wallet/dto/response/UserWalletTransactionDto.java
+++ b/src/main/java/com/example/onlyone/domain/wallet/dto/response/UserWalletTransactionDto.java
@@ -17,6 +17,7 @@ public class UserWalletTransactionDto {
     private String title;
     private WalletTransactionStatus status;
     private String mainImage;
+    private int amount;
     private LocalDateTime createdAt;
 
     public static UserWalletTransactionDto from(WalletTransaction walletTransaction, String title, String mainImage) {
@@ -25,6 +26,7 @@ public class UserWalletTransactionDto {
                 .title(title)
                 .status(walletTransaction.getWalletTransactionStatus())
                 .mainImage(mainImage)
+                .amount(walletTransaction.getAmount())
                 .createdAt(walletTransaction.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/example/onlyone/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/onlyone/global/config/SwaggerConfig.java
@@ -18,38 +18,31 @@ import org.springframework.http.HttpHeaders;
 @RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {
-
     @Bean
-    public OpenAPI openAPI() {
-        return new OpenAPI();
+    public OpenAPI openAPI() { // Security 스키마 설정
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth", bearerAuth))
+                .security(Arrays.asList(securityRequirement));
     }
 
-//
-//    @Bean
-//    public OpenAPI openAPI() { // Security 스키마 설정
-//        SecurityScheme bearerAuth = new SecurityScheme()
-//                .type(SecurityScheme.Type.HTTP)
-//                .scheme("bearer")
-//                .bearerFormat("JWT")
-//                .in(SecurityScheme.In.HEADER)
-//                .name(HttpHeaders.AUTHORIZATION);
-//
-//        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
-//
-//        return new OpenAPI()
-//                .components(new Components()
-//                        .addSecuritySchemes("bearerAuth", bearerAuth))
-//                .security(Arrays.asList(securityRequirement));
-//    }
-//
-//
-//    @Bean
-//    public GroupedOpenApi coreOpenApi() {
-//        String[] paths = {"/**"};
-//
-//        return GroupedOpenApi.builder()
-//                .group("OnlyOne")
-//                .pathsToMatch(paths)
-//                .build();
-//    }
+
+    @Bean
+    public GroupedOpenApi coreOpenApi() {
+        String[] paths = {"/**"};
+
+        return GroupedOpenApi.builder()
+                .group("OnlyOne")
+                .pathsToMatch(paths)
+                .build();
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
- 카카오 로그인 응답 수정 
- 거래 내역 조회 API 오류 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 로그인 응답에 accessToken과 refreshToken을 포함하는 표준화된 응답 구조가 추가되었습니다.
  * OpenAPI(Swagger)에 JWT Bearer 인증이 적용되어 API 문서에서 인증 방식이 명확하게 표시됩니다.

* **버그 수정**
  * 지갑 거래 내역 조회 시 응답이 표준화된 성공 응답 포맷으로 반환됩니다.

* **기능 개선**
  * 카카오 로그인 엔드포인트가 GET에서 POST로 변경되고, refreshToken이 Redis에 2주간 저장됩니다.
  * 지갑 거래 내역 DTO에 거래 금액(amount) 필드가 추가되었습니다.

* **문서화**
  * .gitignore 파일에 항목이 중복 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->