### PR TITLE
[fix] 관심사명 한글로 프론트엔드에 전달 / 홈화면에서 쓰이는 데이터 페이지 사이즈 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 application.yml
 src/main/resources/application.yml
 src/main/resources/application-prod.yml
+src/main/resources/firebase/
 
 .DS_Store
 CLAUDE.md

--- a/src/main/java/com/example/onlyone/domain/club/dto/response/ClubDetailResponseDto.java
+++ b/src/main/java/com/example/onlyone/domain/club/dto/response/ClubDetailResponseDto.java
@@ -31,7 +31,7 @@ public class ClubDetailResponseDto {
 
     private String district;
 
-    private Category category;
+    private String category;
 
     private ClubRole clubRole;
 
@@ -43,7 +43,7 @@ public class ClubDetailResponseDto {
                 .description(club.getDescription())
                 .clubImage(club.getClubImage())
                 .district(club.getDistrict())
-                .category(club.getInterest().getCategory())
+                .category(club.getInterest().getCategory().getKoreanName())
                 .clubRole(clubRole)
                 .build();
     }

--- a/src/main/java/com/example/onlyone/domain/interest/entity/Category.java
+++ b/src/main/java/com/example/onlyone/domain/interest/entity/Category.java
@@ -4,15 +4,24 @@ import com.example.onlyone.global.exception.CustomException;
 import com.example.onlyone.global.exception.ErrorCode;
 
 public enum Category {
-    CULTURE,
-    EXERCISE,
-    TRAVEL,
-    MUSIC,
-    CRAFT,
-    SOCIAL,
-    LANGUAGE,
-    FINANCE;
+    CULTURE("문화"),
+    EXERCISE("운동"),
+    TRAVEL("여행"),
+    MUSIC("음악"),
+    CRAFT("공예"),
+    SOCIAL("사교"),
+    LANGUAGE("외국어"),
+    FINANCE("재테크");
 
+    private final String koreanName;
+
+    Category(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
 
     public static Category from(String value) {
         try {

--- a/src/main/java/com/example/onlyone/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/onlyone/domain/search/controller/SearchController.java
@@ -2,6 +2,7 @@ package com.example.onlyone.domain.search.controller;
 
 import com.example.onlyone.domain.search.dto.request.SearchFilterDto;
 import com.example.onlyone.domain.search.service.SearchService;
+import com.example.onlyone.global.common.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -17,15 +18,16 @@ public class SearchController {
 
     @Operation(summary = "사용자 맞춤 추천", description = "사용자의 관심사 및 지역 기반으로 모임을 추천합니다.")
     @GetMapping("/recommendations")
-    public ResponseEntity<?> recommendedClubs(@RequestParam(defaultValue = "0") int page) {
-        return ResponseEntity.ok(searchService.recommendedClubs(page));
+    public ResponseEntity<?> recommendedClubs(@RequestParam(defaultValue = "0") int page,
+                                              @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(CommonResponse.success(searchService.recommendedClubs(page, size)));
     }
 
     @Operation(summary = "모임 검색 (관심사)", description = "관심사 기반으로 모임을 검색합니다.")
     @GetMapping("/interests")
     public ResponseEntity<?> searchClubByInterest(@RequestParam Long interestId,
                                                   @RequestParam(defaultValue = "0") int page) {
-        return ResponseEntity.ok(searchService.searchClubByInterest(interestId, page));
+        return ResponseEntity.ok(CommonResponse.success(searchService.searchClubByInterest(interestId, page)));
     }
 
     @Operation(summary = "모임 검색 (지역)", description = "지역 기반으로 모임을 검색합니다.")
@@ -33,7 +35,7 @@ public class SearchController {
     public ResponseEntity<?> searchClubByLocation(@RequestParam String city,
                                                   @RequestParam String district,
                                                   @RequestParam(defaultValue = "0") int page) {
-        return ResponseEntity.ok(searchService.searchClubByLocation(city, district, page));
+        return ResponseEntity.ok(CommonResponse.success(searchService.searchClubByLocation(city, district, page)));
     }
 
 
@@ -61,12 +63,13 @@ public class SearchController {
                 .page(page)
                 .build();
                 
-        return ResponseEntity.ok(searchService.searchClubs(filter));
+        return ResponseEntity.ok(CommonResponse.success(searchService.searchClubs(filter)));
     }
 
     @Operation(summary = "함께하는 멤버들의 다른 모임", description = "내가 속한 모임의 다른 멤버들이 가입한 다른 모임을 조회합니다.")
     @GetMapping("/teammates-clubs")
-    public ResponseEntity<?> getClubsByTeammates(@RequestParam(defaultValue = "0") int page) {
-        return ResponseEntity.ok(searchService.getClubsByTeammates(page));
+    public ResponseEntity<?> getClubsByTeammates(@RequestParam(defaultValue = "0") int page,
+                                                 @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(CommonResponse.success(searchService.getClubsByTeammates(page, size)));
     }
 }

--- a/src/main/java/com/example/onlyone/domain/search/dto/response/ClubResponseDto.java
+++ b/src/main/java/com/example/onlyone/domain/search/dto/response/ClubResponseDto.java
@@ -22,7 +22,7 @@ public class ClubResponseDto {
                 .clubId(club.getClubId())
                 .name(club.getName())
                 .description(club.getDescription())
-                .interest(club.getInterest().getCategory().toString())
+                .interest(club.getInterest().getCategory().getKoreanName())
                 .district(club.getDistrict())
                 .memberCount(memberCount)
                 .image(club.getClubImage())

--- a/src/main/java/com/example/onlyone/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/onlyone/domain/search/service/SearchService.java
@@ -2,6 +2,7 @@ package com.example.onlyone.domain.search.service;
 
 import com.example.onlyone.domain.club.entity.Club;
 import com.example.onlyone.domain.club.repository.ClubRepository;
+import com.example.onlyone.domain.interest.entity.Category;
 import com.example.onlyone.domain.search.dto.request.SearchFilterDto;
 import com.example.onlyone.domain.search.dto.response.ClubResponseDto;
 import com.example.onlyone.domain.user.entity.User;
@@ -28,8 +29,8 @@ public class SearchService {
     private final UserInterestRepository userInterestRepository;
 
     // 사용자 맞춤 추천
-    public List<ClubResponseDto> recommendedClubs(int page) {
-        PageRequest pageRequest = PageRequest.of(page, 20);
+    public List<ClubResponseDto> recommendedClubs(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
         User user = userService.getCurrentUser();
 
         // 사용자 관심사 조회
@@ -96,8 +97,8 @@ public class SearchService {
     }
 
     // 함께하는 멤버들의 다른 모임 조회
-    public List<ClubResponseDto> getClubsByTeammates(int page) {
-        PageRequest pageRequest = PageRequest.of(page, 20);
+    public List<ClubResponseDto> getClubsByTeammates(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
         User currentUser = userService.getCurrentUser();
         List<Object[]> resultList = clubRepository.findClubsByTeammates(currentUser.getUserId(), pageRequest);
 
@@ -116,13 +117,16 @@ public class SearchService {
     // 키워드 검색 결과 전용 변환
     private List<ClubResponseDto> convertKeywordSearchResults(List<Object[]> results) {
         return results.stream().map(result -> {
+            String categoryName = (String) result[5];
+            String koreanCategoryName = Category.valueOf(categoryName).getKoreanName();
+            
             return ClubResponseDto.builder()
                     .clubId(((Number) result[0]).longValue())
                     .name((String) result[1])
                     .description((String) result[2])
                     .district((String) result[3])
                     .image((String) result[4])
-                    .interest((String) result[5])
+                    .interest(koreanCategoryName)
                     .memberCount(((Number) result[6]).longValue())
                     .build();
         }).toList();


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

- 관심사(카테고리)명을 한글로 반환하도록 수정
- 홈 화면에서는 5개씩 모임 리스트업 할 수 있도록 사이즈 설정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 추천 동아리 및 팀원 동아리 조회 시 페이지 크기를 지정할 수 있는 size 파라미터가 추가되었습니다.

* **버그 수정**
  * 검색 결과 및 동아리 상세 조회에서 관심사 카테고리가 한글 이름으로 표시됩니다.

* **스타일**
  * 모든 검색 관련 응답이 일관된 공통 응답 포맷(CommonResponse.success())으로 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->